### PR TITLE
update release number on footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ blurb:
     [CC0-1.0](https://creativecommons.org/share-your-work/public-domain/cc0/){:target="_blank"},
     unless otherwise specified.
 
-    Galaxy Australia is currently running Galaxy version 20.05 (June 2020)
+    Galaxy Australia is currently running Galaxy version 20.09 (September 2020)
 
 sass:
   sass_dir: assets/css


### PR DESCRIPTION
to 20.09 (November 2020).  Or should it be September?  It was released in November
